### PR TITLE
Remove max-api from package.json

### DIFF
--- a/n4m-vimeo/.gitignore
+++ b/n4m-vimeo/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .env
+.DS_Store
+docs/.DS_Store

--- a/n4m-vimeo/package.json
+++ b/n4m-vimeo/package.json
@@ -9,7 +9,6 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^6.2.0",
-    "max-api": "^1.0.1",
     "vimeo": "^2.1.1"
   }
 }


### PR DESCRIPTION
The node module `max-api` comes built-in with Max 8.  
An empty placeholder package is, however, listed in the npm registry to prevent misuse of the `max-api` name, potentially causing namespace conflicts.
More information here: https://www.npmjs.com/package/max-api

This change removes max-api from package.json to ensure that the in-built module is utilized and not the placeholder package from npm.